### PR TITLE
Correct mixing of 16bit signed data.

### DIFF
--- a/mod.c
+++ b/mod.c
@@ -439,11 +439,11 @@ void startplaying(int loud)
   {
     if (mod.tracks < 5)
      for (j=0;j<16640;j++)
-           vol.vol_table16[j] = (vol_adj[(j >> 8)] * ((j-0x80) & 0xFF)); 
+           vol.vol_table16[j] = (vol_adj[(j >> 8)] * (int)((char)j) );
      else
      for (j=0;j<16640;j++)
      {
-           vol.vol_table16[j] = (vol_adj[(j >> 8)] * ((j-0x80) & 0xFF)) >> 1;
+           vol.vol_table16[j] = (vol_adj[(j >> 8)] * (int)((char)j) ) >> 1;
        }
   } else
   {

--- a/mod.h
+++ b/mod.h
@@ -30,15 +30,15 @@
 
 #ifdef NEAR_FAR_PTR
 typedef uint8 near *sample8_near;
-typedef uint16 near *sample16_near;
+typedef int16 near *sample16_near;
 typedef uint8 far *sample8_far;
-typedef uint16 far *sample16_far;
+typedef int16 far *sample16_far;
 typedef uint8 far *pattern_ptr;
 #else
 typedef uint8 *sample8_near;
-typedef uint16 *sample16_near;
+typedef int16 *sample16_near;
 typedef uint8 *sample8_far;
-typedef uint16 *sample16_far;
+typedef int16 *sample16_far;
 typedef uint8 *pattern_ptr;
 #endif
 
@@ -202,8 +202,8 @@ void startplaying(int loud);
 void updatetracks(void);
 void mixtrack_8_stereo(track_info *track, uint8 *buffer, uint16 buflen, uint32 channel);
 void mixtrack_8_mono(track_info *track, uint8 *buffer, uint16 buflen);
-void mixtrack_16_stereo(track_info *track, uint16 *buffer, uint16 buflen, uint32 channel);
-void mixtrack_16_mono(track_info *track, uint16 *buffer, uint16 buflen);
+void mixtrack_16_stereo(track_info *track, int16 *buffer, uint16 buflen, uint32 channel);
+void mixtrack_16_mono(track_info *track, int16 *buffer, uint16 buflen);
 
 extern uint8                   sintable[];
 extern song_data               mod;

--- a/play.c
+++ b/play.c
@@ -44,7 +44,7 @@
 union
 {
   uint8                   rot_buf[ROT_BUF_SIZE];
-  uint16                  rot_buf16[ROT_BUF_SIZE];
+  int16                   rot_buf16[ROT_BUF_SIZE];
 } buf;
 
 void updatetracks(void)
@@ -128,9 +128,9 @@ void play_mod(int loud)
     if (bit16)
     {
       if (stereo)
-         for (d=&buf.rot_buf16[bpm_samples << 1];d > buf.rot_buf16;*(--d) = 0x8000);
+         for (d=&buf.rot_buf16[bpm_samples << 1];d > buf.rot_buf16;*(--d) = 0x0000);
          else
-         for (d=&buf.rot_buf16[bpm_samples];d > buf.rot_buf16;*(--d) = 0x8000);
+         for (d=&buf.rot_buf16[bpm_samples];d > buf.rot_buf16;*(--d) = 0x0000);
     } else
     {
       if (stereo)


### PR DESCRIPTION
The BUGS file describe a problem with "popping". This is caused by the 16 bit mixing not being correct. It's being done as unsigned ints and then reinterpreted as signed data when written to the DSP:s. This PR changes the logic so that the mixing is done with signed ints. Tested with linux_dsp but I expect it to work with the other DSP:s as well.